### PR TITLE
Adapt Docker file to Debian stretch and up-to-date versions of Glewlwyd and its dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.8
+FROM debian:stretch
 
 # Install required packages
 RUN apt-get update && \
@@ -9,11 +9,11 @@ RUN apt-get update && \
     libconfig-dev \
     libjansson-dev \
     libgnutls28-dev \
+    libssl-dev \
     libldap2-dev \
     libmicrohttpd-dev \
-    libmysqlclient-dev \
+    libmariadbclient-dev \
     libsqlite3-dev \
-    libssl-dev \
     libtool \
     make \
     mariadb-client \
@@ -22,11 +22,11 @@ RUN apt-get update && \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-ARG GLEWLWYD_VERSION=1.1
-ARG HOEL_VERSION=1.1
-ARG LIBJWT_VERSION=1.7.4
-ARG ORCANIA_VERSION=1.1
-ARG ULFIUS_VERSION=2.0.1
+ARG GLEWLWYD_VERSION=1.2.4
+ARG HOEL_VERSION=1.3
+ARG LIBJWT_VERSION=1.8.0
+ARG ORCANIA_VERSION=1.1.1
+ARG ULFIUS_VERSION=2.2.2
 ARG YDER_VERSION=1.1
 
 # libtool and autoconf may be required, install them with 'sudo apt-get install libtool autoconf'
@@ -60,27 +60,27 @@ RUN cd /opt && \
 
 # Install Ulfius
     cd /opt && \
-    wget https://github.com/babelouest/ulfius/archive/${ULFIUS_VERSION}.tar.gz && \
-    tar -zxvf ${ULFIUS_VERSION}.tar.gz && \
-    rm ${ULFIUS_VERSION}.tar.gz && \
+    wget https://github.com/babelouest/ulfius/archive/v${ULFIUS_VERSION}.tar.gz && \
+    tar -zxvf v${ULFIUS_VERSION}.tar.gz && \
+    rm v${ULFIUS_VERSION}.tar.gz && \
     cd ulfius-${ULFIUS_VERSION}/src/ && \
     make && \
     make install && \
 
 # Install Hoel
     cd /opt && \
-    wget https://github.com/babelouest/hoel/archive/${HOEL_VERSION}.tar.gz && \
-    tar -zxvf ${HOEL_VERSION}.tar.gz && \
-    rm ${HOEL_VERSION}.tar.gz && \
+    wget https://github.com/babelouest/hoel/archive/v${HOEL_VERSION}.tar.gz && \
+    tar -zxvf v${HOEL_VERSION}.tar.gz && \
+    rm v${HOEL_VERSION}.tar.gz && \
     cd hoel-${HOEL_VERSION}/src/ && \
     make && \
     make install && \
 
 # Install Glewlwyd
     cd / && \
-    wget https://github.com/babelouest/glewlwyd/archive/${GLEWLWYD_VERSION}.tar.gz && \
-    tar -zxvf ${GLEWLWYD_VERSION}.tar.gz && \
-    rm ${GLEWLWYD_VERSION}.tar.gz && \
+    wget https://github.com/babelouest/glewlwyd/archive/v${GLEWLWYD_VERSION}.tar.gz && \
+    tar -zxvf v${GLEWLWYD_VERSION}.tar.gz && \
+    rm v${GLEWLWYD_VERSION}.tar.gz && \
     mv glewlwyd-${GLEWLWYD_VERSION}/ /glewlwyd && \
     cd /glewlwyd/src && \
     make && \


### PR DESCRIPTION
I try to get rid of libssl-dev becuase libjwt should be built without openssl now (`./configure --without-openssl`), but it looks like it's not possible yet.

I'm still struggling with docker commands but it looks promising.